### PR TITLE
tweaks for before QA

### DIFF
--- a/index.cjsx
+++ b/index.cjsx
@@ -18,6 +18,8 @@ ChapterSectionMixin = require './src/components/chapter-section-mixin'
 GetPositionMixin = require './src/components/get-position-mixin'
 ResizeListenerMixin = require './src/components/resize-listener-mixin'
 
+KeysHelper = require './src/helpers/keys'
+
 module.exports = {
   Exercise,
   ExerciseGroup,
@@ -41,5 +43,7 @@ module.exports = {
   GetPositionMixin,
   ResizeListenerMixin,
 
-  SpyMode
+  SpyMode,
+
+  KeysHelper
 }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "openstax-react-components",
   "version": "0.0.0",
   "description": "OpenStax shared React components",
-  "main": "dist/main.min.js",
+  "main": "index",
   "scripts": {
     "test": "gulp test && gulp prod",
     "coverage": "gulp coverage",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "classnames": "^2.1.3",
     "eventemitter2": "^0.4.14",
     "font-awesome": "^4.4.0",
+    "keymaster": "^1.6.2",
     "markdown-it": "^4.1.1",
     "moment": "^2.9.0",
     "underscore": "~1.8.2"

--- a/src/components/exercise/modes.cjsx
+++ b/src/components/exercise/modes.cjsx
@@ -48,11 +48,11 @@ ExReviewControls = React.createClass
     canRefreshMemory: false
 
   render: ->
-    {review, canTryAnother, tryAnother, isRecovering} = @props
+    {review, canTryAnother, tryAnother, isRecovering, children} = @props
     {canRefreshMemory, refreshMemory} = @props
     {isContinueFailed, waitingText, onContinue, isContinueEnabled} = @props
 
-    continueButtonText = if canTryAnother then 'Move On' else ''
+    continueButtonText = if canTryAnother then 'Move On' else children
 
     if canTryAnother
       tryAnotherButton = <AsyncButton

--- a/src/components/exercise/modes.cjsx
+++ b/src/components/exercise/modes.cjsx
@@ -156,7 +156,7 @@ ExMultipleChoice = React.createClass
     @props.onAnswerChanged?(answer)
 
   render: ->
-    {content, free_response, correct_answer_id, choicesEnabled} = @props
+    {content, free_response, correct_answer_id, choicesEnabled, answerKeySet} = @props
     question = content.questions[0]
     {answerId} = @state
 
@@ -167,7 +167,8 @@ ExMultipleChoice = React.createClass
         choicesEnabled={choicesEnabled}
         model={question}
         exercise_uid={content.uid}
-        correct_answer_id={correct_answer_id}>
+        correct_answer_id={correct_answer_id}
+        keySet={answerKeySet}>
         <FreeResponse free_response={free_response}/>
       </Question>
     </div>

--- a/src/components/exercise/props.cjsx
+++ b/src/components/exercise/props.cjsx
@@ -45,6 +45,7 @@ EXERCISE_STEP_CARD_PROP_TYPES = _.extend({}, CONTINUE_PROP_TYPES, REVIEW_CONTROL
 EXERCISE_STEP_CARD_PROP_TYPES.step = React.PropTypes.shape(STEP_PROP_TYPES).isRequired
 EXERCISE_STEP_CARD_PROP_TYPES.footer = React.PropTypes.node.isRequired
 EXERCISE_STEP_CARD_PROP_TYPES.pinned = React.PropTypes.bool
+EXERCISE_STEP_CARD_PROP_TYPES.allowKeyNav = React.PropTypes.bool
 EXERCISE_STEP_CARD_PROP_TYPES.panel = React.PropTypes.oneOf(['review', 'multiple-choice', 'free-response', 'teacher-read-only'])
 EXERCISE_STEP_CARD_PROP_TYPES.review = React.PropTypes.string
 

--- a/src/components/exercise/step-card.cjsx
+++ b/src/components/exercise/step-card.cjsx
@@ -28,6 +28,12 @@ CONTROLS =
   'review': ExReviewControls
   'teacher-read-only': ExContinueButton
 
+CONTROLS_TEXT =
+  'free-response': 'Answer'
+  'multiple-choice': 'Submit'
+  'review': 'Next Question'
+  'teacher-read-only': 'Next Question'
+
 CONTINUE_CHECKS =
   'free-response': 'freeResponse'
   'multiple-choice': 'answerId'
@@ -107,10 +113,12 @@ ExerciseStepCard = React.createClass
     ExPanel = PANELS[panel]
     ControlButtons = CONTROLS[panel]
     onInputChange = ON_CHANGE[panel]
+    controlText = CONTROLS_TEXT[panel]
 
     controlProps = _.pick(@props, props.ExReviewControls)
     controlProps.isContinueEnabled = isContinueEnabled and @isContinueEnabled(@props, @state)
     controlProps.onContinue = @onContinue
+    controlProps.children = controlText
 
     panelProps = _.omit(@props, props.notPanel)
     panelProps.choicesEnabled = not waitingText

--- a/src/components/exercise/step-card.cjsx
+++ b/src/components/exercise/step-card.cjsx
@@ -2,6 +2,7 @@ React = require 'react/addons'
 _ = require 'underscore'
 
 classnames = require 'classnames'
+keymaster = require 'keymaster'
 
 ExerciseGroup = require './group'
 {CardBody} = require '../pinned-header-footer-card/sections'
@@ -59,8 +60,16 @@ ExerciseStepCard = React.createClass
     disabled: false
     isContinueEnabled: true
     footer: <ExerciseDefaultFooter/>
+    allowKeyNext: true
+
   getInitialState: ->
     stepState = @getStepState(@props)
+
+  componentWillMount: ->
+    keymaster('enter', @onContinue) if @props.allowKeyNext
+
+  componentWilUnmount: ->
+    keymaster.unbind('enter') if @props.allowKeyNext
 
   shouldComponentUpdate: (nextProps, nextState) ->
     not (_.isEqual(@props, nextProps) and

--- a/src/helpers/keys.coffee
+++ b/src/helpers/keys.coffee
@@ -1,0 +1,23 @@
+_ = require 'underscore'
+keymaster = require 'keymaster'
+
+keysHelper = {}
+
+handleKeys = (keyFN, keys, keymasterArgs...) ->
+  return keys? unless keys
+  # cover for some annoying keymaster bugs
+  if _.isArray(keys)
+    _.each(keys, (key) ->
+      keyFN key.toString(), keymasterArgs...
+    )
+  else
+    keyFN keys, keymasterArgs...
+
+keysHelper.on = _.partial(handleKeys, keymaster)
+
+keysHelper.off = _.partial(handleKeys, keymaster.unbind)
+
+keysHelper.getCharFromNumKey = (numKey, offset = 1) ->
+  String.fromCharCode((97 - offset) + numKey)
+
+module.exports = keysHelper


### PR DESCRIPTION
- [x] button question text change between steps
- [x] keyboard control with `enter`, and answers both numeric and alpha based
  - a, b, c, d, ...
  - 1, 2, 3, 4, ...
  - see also openstax/tutor-js#717

Matches mockups

![screen shot 2015-12-01 at 12 17 25 pm](https://cloud.githubusercontent.com/assets/2483873/11509769/b146e8e8-9825-11e5-9ea3-5e04f096cd7a.png)
![screen shot 2015-12-01 at 12 17 34 pm](https://cloud.githubusercontent.com/assets/2483873/11509767/b141fd38-9825-11e5-8f69-8f58ade54a25.png)
![screen shot 2015-12-01 at 12 17 40 pm](https://cloud.githubusercontent.com/assets/2483873/11509768/b1433356-9825-11e5-958e-daba4d24d4d4.png)
