### PR TITLE
prevent class name collision with exercise

### DIFF
--- a/resources/styles/components/question.less
+++ b/resources/styles/components/question.less
@@ -86,6 +86,12 @@
   }
 }
 
+.answer-bubble(correct-answer){
+  border-color: @correct-answer-color;
+  background-color: @correct-answer-color;
+  color: @openstax-white;
+}
+
 .answer-left-block(){
   display: block;
   float: left;
@@ -123,6 +129,22 @@
   color: @correct-answer-color;
   .answer-letter {
     .answer-bubble(correct);
+  }
+}
+
+.answer(correct-answer){
+  color: @correct-answer-color;
+  .answer-letter {
+    .answer-bubble(correct-answer);
+  }
+
+  &::before {
+    .answer-fa-icon();
+    content: @fa-var-hand-o-right;
+    width: @answer-bubble-size;
+    margin-left: -1 * @answer-bubble-size;
+    text-align: center;
+    .answer-left-block();
   }
 }
 
@@ -230,15 +252,7 @@
 
     .answer-correct:not(.answer-checked) {
       .answer-label {
-        &::before {
-          .answer-fa-icon();
-          content: @fa-var-hand-o-right;
-          color: @correct-answer-color;
-          width: @answer-bubble-size;
-          margin-left: -1 * @answer-bubble-size;
-          text-align: center;
-          .answer-left-block();
-        }
+        .answer(correct-answer);
       }
     }
   }

--- a/src/components/breadcrumb/index.cjsx
+++ b/src/components/breadcrumb/index.cjsx
@@ -62,7 +62,7 @@ Breadcrumb = React.createClass
     if isEnd
       title = "#{step.title} Completion"
 
-    classes = classnames 'openstax-breadcrumbs-step', 'icon-stack', 'icon-lg', step.group, crumbType, className,
+    classes = classnames 'openstax-breadcrumbs-step', 'icon-stack', 'icon-lg', step.group, "breadcrumb-#{crumbType}", className,
       current: isCurrent
       active: isCurrent
       completed: isCompleted


### PR DESCRIPTION
exercise classes from webview was leaking into cc after moving cc up into content

also, make correct answer more prominent:

![screen shot 2015-12-07 at 11 21 41 am](https://cloud.githubusercontent.com/assets/2483873/11634213/daa76b28-9cd4-11e5-94f4-9890dc958179.png)
