### PR TITLE
move exercises rendering to one component as opposed the mode version

### DIFF
--- a/src/components/exercise/controls.cjsx
+++ b/src/components/exercise/controls.cjsx
@@ -3,9 +3,6 @@ BS = require 'react-bootstrap'
 _ = require 'underscore'
 
 AsyncButton = require '../buttons/async-button'
-{ExPanel} = require './panel'
-ExerciseGroup = require './group'
-
 {propTypes, props} = require './props'
 
 ExContinueButton = React.createClass
@@ -85,29 +82,4 @@ ExReviewControls = React.createClass
       {continueButton}
     </div>
 
-
-ExFreeResponse = React.createClass
-  displayName: 'ExFreeResponse'
-  propTypes: propTypes.ExFreeResponse
-  render: ->
-    <ExPanel {...@props} panel='free-response'/>
-
-ExMultipleChoice = React.createClass
-  displayName: 'ExMulitpleChoice'
-  propTypes: propTypes.ExMulitpleChoice
-  render: ->
-    <ExPanel {...@props} panel='multiple-choice'/>
-
-ExReview = React.createClass
-  displayName: 'ExReview'
-  propTypes: propTypes.ExReview
-  render: ->
-    <ExPanel {...@props} panel='review'/>
-
-module.exports = {
-  ExContinueButton,
-  ExReviewControls,
-  ExFreeResponse,
-  ExMultipleChoice,
-  ExReview
-}
+module.exports = {ExContinueButton, ExReviewControls}

--- a/src/components/exercise/mode.cjsx
+++ b/src/components/exercise/mode.cjsx
@@ -6,7 +6,8 @@ Question = require '../question'
 FreeResponse = require './free-response'
 
 {propTypes, props} = require './props'
-modeProps = _.extend {}, propTypes.ExFreeResponse, propTypes.ExMulitpleChoice, propTypes.ExReview
+modeType = propTypes.ExerciseStepCard.panel
+modeProps = _.extend {}, propTypes.ExFreeResponse, propTypes.ExMulitpleChoice, propTypes.ExReview, mode: modeType
 
 ExMode = React.createClass
   displayName: 'ExMode'

--- a/src/components/exercise/mode.cjsx
+++ b/src/components/exercise/mode.cjsx
@@ -6,11 +6,11 @@ Question = require '../question'
 FreeResponse = require './free-response'
 
 {propTypes, props} = require './props'
-panelProps = _.extend {}, propTypes.ExFreeResponse, propTypes.ExMulitpleChoice, propTypes.ExReview
+modeProps = _.extend {}, propTypes.ExFreeResponse, propTypes.ExMulitpleChoice, propTypes.ExReview
 
-ExPanel = React.createClass
-  displayName: 'ExPanel'
-  propTypes: panelProps
+ExMode = React.createClass
+  displayName: 'ExMode'
+  propTypes: modeProps
   getDefaultProps: ->
     disabled: false
     free_response: ''
@@ -22,25 +22,25 @@ ExPanel = React.createClass
     answerId: answer_id
 
   componentDidMount: ->
-    {panel} = @props
-    @focusBox() if panel is 'free-response'
+    {mode} = @props
+    @focusBox() if mode is 'free-response'
 
   componentDidUpdate: (nextProps, nextState) ->
-    {panel} = nextProps
-    @focusBox() if panel is 'free-response'
+    {mode} = nextProps
+    @focusBox() if mode is 'free-response'
 
   componentWillReceiveProps: (nextProps) ->
-    {panel, free_response, answer_id} = nextProps
+    {mode, free_response, answer_id} = nextProps
 
-    switch panel
+    switch mode
       when 'free-response'
         @setState(freeResponse: free_response) if @state.freeResponse isnt free_response
       when 'multiple-choice'
         @setState(answerId: answer_id) if @state.answerId isnt answer_id
 
   focusBox: ->
-    {focus, panel} = @props
-    @refs.freeResponse?.getDOMNode?().focus?() if focus and panel is 'free-response'
+    {focus, mode} = @props
+    @refs.freeResponse?.getDOMNode?().focus?() if focus and mode is 'free-response'
 
   onFreeResponseChange: ->
     freeResponse = @refs.freeResponse?.getDOMNode()?.value
@@ -48,15 +48,15 @@ ExPanel = React.createClass
     @props.onFreeResponseChange?(freeResponse)
 
   onAnswerChanged: (answer) ->
-    return if answer.id is @state.answerId or @props.panel isnt 'multiple-choice'
+    return if answer.id is @state.answerId or @props.mode isnt 'multiple-choice'
     @setState {answerId: answer.id}
     @props.onAnswerChanged?(answer)
 
   getFreeResponse: ->
-    {panel, free_response, disabled} = @props
+    {mode, free_response, disabled} = @props
     {freeResponse} = @state
 
-    if panel is 'free-response'
+    if mode is 'free-response'
       <textarea
         disabled={disabled}
         ref='freeResponse'
@@ -68,18 +68,18 @@ ExPanel = React.createClass
       <FreeResponse free_response={free_response}/>
 
   render: ->
-    {panel, content, onChangeAnswerAttempt, answerKeySet, choicesEnabled} = @props
+    {mode, content, onChangeAnswerAttempt, answerKeySet, choicesEnabled} = @props
     {answerId} = @state
 
     answerKeySet = null unless choicesEnabled
     question = content.questions[0]
-    question = _.omit(question, 'answers') if panel is 'free-response'
+    question = _.omit(question, 'answers') if mode is 'free-response'
 
     questionProps = _.pick(@props, 'processHtmlAndMath', 'choicesEnabled', 'correct_answer_id', 'feedback_html', 'type')
-    if panel is 'multiple-choice'
+    if mode is 'multiple-choice'
       changeProps =
         onChange: @onAnswerChanged
-    else if panel is 'review'
+    else if mode is 'review'
       changeProps =
         onChangeAttempt: onChangeAnswerAttempt
 
@@ -97,4 +97,4 @@ ExPanel = React.createClass
     </div>
 
 
-module.exports = {ExPanel}
+module.exports = {ExMode}

--- a/src/components/exercise/modes.cjsx
+++ b/src/components/exercise/modes.cjsx
@@ -2,13 +2,9 @@ React = require 'react'
 BS = require 'react-bootstrap'
 _ = require 'underscore'
 
-ArbitraryHtmlAndMath = require '../html'
-Question = require '../question'
-FreeResponse = require './free-response'
 AsyncButton = require '../buttons/async-button'
-
+{ExPanel} = require './panel'
 ExerciseGroup = require './group'
-{CardBody} = require '../pinned-header-footer-card/sections'
 
 {propTypes, props} = require './props'
 
@@ -93,122 +89,20 @@ ExReviewControls = React.createClass
 ExFreeResponse = React.createClass
   displayName: 'ExFreeResponse'
   propTypes: propTypes.ExFreeResponse
-  getDefaultProps: ->
-    disabled: false
-    free_response: ''
-
-  getInitialState: ->
-    freeResponse: @props.free_response
-
-  componentDidMount: ->
-    @focusBox()
-  componentDidUpdate: ->
-    @focusBox()
-
-  componentWillReceiveProps: (nextProps) ->
-    if @state.freeResponse isnt nextProps.free_response
-      @setState(freeResponse: nextProps.free_response)
-
-  focusBox: ->
-    @refs.freeResponse.getDOMNode().focus() if @props.focus
-
-  onFreeResponseChange: ->
-    freeResponse = @refs.freeResponse.getDOMNode().value
-    @setState({freeResponse})
-    @props.onFreeResponseChange?(freeResponse)
-
   render: ->
-    {content, disabled, onFreeResponseChange, free_response} = @props
-    {freeResponse} = @state
-    question = content.questions[0]
-    htmlAndMathProps = _.pick(@props, 'processHtmlAndMath')
-
-    <div className='openstax-exercise'>
-      <ArbitraryHtmlAndMath
-        {...htmlAndMathProps}
-        className='stimulus'
-        block={true}
-        html={content.stimulus_html} />
-      <ArbitraryHtmlAndMath
-        {...htmlAndMathProps}
-        className='stem'
-        block={true}
-        html={question.stem_html} />
-      <textarea
-        disabled={disabled}
-        ref='freeResponse'
-        placeholder='Enter your response'
-        value={freeResponse}
-        onChange={@onFreeResponseChange}
-      />
-      <div className="exercise-uid">{content.uid}</div>
-    </div>
-
+    <ExPanel {...@props} panel='free-response'/>
 
 ExMultipleChoice = React.createClass
   displayName: 'ExMulitpleChoice'
   propTypes: propTypes.ExMulitpleChoice
-  getDefaultProps: ->
-    answer_id: ''
-
-  getInitialState: ->
-    {answer_id} = @props
-    answerId: answer_id
-
-  componentWillReceiveProps: (nextProps) ->
-    if @state.answerId isnt nextProps.answer_id
-      @setState(answerId: nextProps.answer_id)
-
-  onAnswerChanged: (answer) ->
-    return if answer.id is @state.answerId
-    @setState {answerId: answer.id}
-    @props.onAnswerChanged?(answer)
-
   render: ->
-    {content, free_response, correct_answer_id, choicesEnabled, answerKeySet} = @props
-    question = content.questions[0]
-    {answerId} = @state
-    htmlAndMathProps = _.pick(@props, 'processHtmlAndMath')
-
-    <div className='openstax-exercise'>
-      <Question
-        {...htmlAndMathProps}
-        answer_id={answerId}
-        onChange={@onAnswerChanged}
-        choicesEnabled={choicesEnabled}
-        model={question}
-        exercise_uid={content.uid}
-        correct_answer_id={correct_answer_id}
-        keySet={answerKeySet}>
-        <FreeResponse free_response={free_response}/>
-      </Question>
-    </div>
-
+    <ExPanel {...@props} panel='multiple-choice'/>
 
 ExReview = React.createClass
   displayName: 'ExReview'
   propTypes: propTypes.ExReview
-
   render: ->
-    {content, free_response, answer_id, correct_answer_id, feedback_html, type, onChangeAnswerAttempt} = @props
-    question = content.questions[0]
-    htmlAndMathProps = _.pick(@props, 'processHtmlAndMath')
-
-    <div className='openstax-exercise'>
-      <Question
-        {...htmlAndMathProps}
-        key='step-question'
-        model={question}
-        answer_id={answer_id}
-        exercise_uid={content.uid}
-        correct_answer_id={correct_answer_id}
-        feedback_html={feedback_html}
-        type={type}
-        onChangeAttempt={onChangeAnswerAttempt}>
-        <FreeResponse free_response={free_response}/>
-      </Question>
-    </div>
-
+    <ExPanel {...@props} panel='review'/>
 
 module.exports = {
   ExContinueButton,

--- a/src/components/exercise/panel.cjsx
+++ b/src/components/exercise/panel.cjsx
@@ -1,0 +1,100 @@
+React = require 'react'
+_ = require 'underscore'
+
+ArbitraryHtmlAndMath = require '../html'
+Question = require '../question'
+FreeResponse = require './free-response'
+
+{propTypes, props} = require './props'
+panelProps = _.extend {}, propTypes.ExFreeResponse, propTypes.ExMulitpleChoice, propTypes.ExReview
+
+ExPanel = React.createClass
+  displayName: 'ExPanel'
+  propTypes: panelProps
+  getDefaultProps: ->
+    disabled: false
+    free_response: ''
+    answer_id: ''
+  getInitialState: ->
+    {free_response, answer_id} = @props
+
+    freeResponse: free_response
+    answerId: answer_id
+
+  componentDidMount: ->
+    {panel} = @props
+    @focusBox() if panel is 'free-response'
+
+  componentDidUpdate: (nextProps, nextState) ->
+    {panel} = nextProps
+    @focusBox() if panel is 'free-response'
+
+  componentWillReceiveProps: (nextProps) ->
+    {panel, free_response, answer_id} = nextProps
+
+    switch panel
+      when 'free-response'
+        @setState(freeResponse: free_response) if @state.freeResponse isnt free_response
+      when 'multiple-choice'
+        @setState(answerId: answer_id) if @state.answerId isnt answer_id
+
+  focusBox: ->
+    {focus, panel} = @props
+    @refs.freeResponse?.getDOMNode?().focus?() if focus and panel is 'free-response'
+
+  onFreeResponseChange: ->
+    freeResponse = @refs.freeResponse?.getDOMNode()?.value
+    @setState({freeResponse})
+    @props.onFreeResponseChange?(freeResponse)
+
+  onAnswerChanged: (answer) ->
+    return if answer.id is @state.answerId or @props.panel isnt 'multiple-choice'
+    @setState {answerId: answer.id}
+    @props.onAnswerChanged?(answer)
+
+  getFreeResponse: ->
+    {panel, free_response, disabled} = @props
+    {freeResponse} = @state
+
+    if panel is 'free-response'
+      <textarea
+        disabled={disabled}
+        ref='freeResponse'
+        placeholder='Enter your response'
+        value={freeResponse}
+        onChange={@onFreeResponseChange}
+      />
+    else
+      <FreeResponse free_response={free_response}/>
+
+  render: ->
+    {panel, content, onChangeAnswerAttempt, answerKeySet, choicesEnabled} = @props
+    {answerId} = @state
+
+    answerKeySet = null unless choicesEnabled
+    question = content.questions[0]
+    question = _.omit(question, 'answers') if panel is 'free-response'
+
+    questionProps = _.pick(@props, 'processHtmlAndMath', 'choicesEnabled', 'correct_answer_id', 'feedback_html', 'type')
+    if panel is 'multiple-choice'
+      changeProps =
+        onChange: @onAnswerChanged
+    else if panel is 'review'
+      changeProps =
+        onChangeAttempt: onChangeAnswerAttempt
+
+    <div className='openstax-exercise'>
+      <Question
+        {...questionProps}
+        {...changeProps}
+        key='step-question'
+        model={question}
+        answer_id={answerId}
+        keySet={answerKeySet}
+        exercise_uid={content.uid}>
+        {@getFreeResponse()}
+      </Question>
+    </div>
+
+
+module.exports = {ExPanel}

--- a/src/components/exercise/step-card.cjsx
+++ b/src/components/exercise/step-card.cjsx
@@ -15,6 +15,8 @@ ExerciseGroup = require './group'
   ExReview
 } = require './modes'
 
+{ExPanel} = require './panel'
+
 {propTypes, props} = require './props'
 
 PANELS =
@@ -129,7 +131,6 @@ ExerciseStepCard = React.createClass
     {step, panel, pinned, isContinueEnabled, waitingText, controlButtons, className, footer} = @props
     {group, related_content} = step
 
-    ExPanel = PANELS[panel]
     ControlButtons = CONTROLS[panel]
     onInputChange = ON_CHANGE[panel]
     controlText = CONTROLS_TEXT[panel]
@@ -140,7 +141,7 @@ ExerciseStepCard = React.createClass
     controlProps.children = controlText
 
     panelProps = _.omit(@props, props.notPanel)
-    panelProps.choicesEnabled = not waitingText
+    panelProps.choicesEnabled = not waitingText and panel is 'multiple-choice'
     panelProps[onInputChange] = @[onInputChange]
 
     footerProps = _.pick(@props, props.StepFooter)
@@ -153,7 +154,8 @@ ExerciseStepCard = React.createClass
       <div className="exercise-#{panel}">
         <ExPanel
           {...step}
-          {...panelProps}/>
+          {...panelProps}
+          panel={panel}/>
         <ExerciseGroup
           key='step-exercise-group'
           group={group}

--- a/src/components/exercise/step-card.cjsx
+++ b/src/components/exercise/step-card.cjsx
@@ -7,23 +7,11 @@ keymaster = require 'keymaster'
 ExerciseGroup = require './group'
 {CardBody} = require '../pinned-header-footer-card/sections'
 
-{
-  ExContinueButton,
-  ExReviewControls,
-  ExFreeResponse,
-  ExMultipleChoice,
-  ExReview
-} = require './modes'
+{ExContinueButton, ExReviewControls} = require './controls'
 
-{ExPanel} = require './panel'
+{ExMode} = require './mode'
 
 {propTypes, props} = require './props'
-
-PANELS =
-  'free-response': ExFreeResponse
-  'multiple-choice': ExMultipleChoice
-  'review': ExReview
-  'teacher-read-only': ExReview
 
 CONTROLS =
   'free-response': ExContinueButton
@@ -152,10 +140,10 @@ ExerciseStepCard = React.createClass
 
     <CardBody className={cardClasses} footer={footer} pinned={pinned}>
       <div className="exercise-#{panel}">
-        <ExPanel
+        <ExMode
           {...step}
           {...panelProps}
-          panel={panel}/>
+          mode={panel}/>
         <ExerciseGroup
           key='step-exercise-group'
           group={group}

--- a/src/components/question.cjsx
+++ b/src/components/question.cjsx
@@ -68,16 +68,27 @@ Answer = React.createClass
     show_all_feedback: false
 
   componentWillMount: ->
+    @setUpKeys()
+
+  componentWillUnmount: ->
+    {keyControl} = @props
+    keysHelper.off(keyControl, 'multiple-choice') if keyControl?
+
+  componentDidUpdate: (prevProps) ->
+    {keyControl, disabled} = @props
+    if prevProps.keyControl? and (disabled or not keyControl?)
+      keysHelper.off(prevProps.keyControl, 'multiple-choice')
+
+    if keyControl? and not disabled and prevProps.keyControl isnt keyControl
+      @setUpKeys()
+
+  setUpKeys: ->
     {answer, onChangeAnswer, disabled, keyControl} = @props
 
     if keyControl and not disabled
       keyInAnswer = _.partial onChangeAnswer, answer
       keysHelper.on keyControl, 'multiple-choice', keyInAnswer
       keymaster.setScope('multiple-choice')
-
-  componentWillUnmount: ->
-    {disabled, keyControl} = @props
-    keysHelper.off(keyControl, 'multiple-choice') if keyControl and not disabled
 
   contextTypes:
     processHtmlAndMath: React.PropTypes.func

--- a/src/components/question.cjsx
+++ b/src/components/question.cjsx
@@ -68,27 +68,33 @@ Answer = React.createClass
     show_all_feedback: false
 
   componentWillMount: ->
-    @setUpKeys()
+    @setUpKeys() if @shouldKey()
 
   componentWillUnmount: ->
     {keyControl} = @props
     keysHelper.off(keyControl, 'multiple-choice') if keyControl?
 
   componentDidUpdate: (prevProps) ->
-    {keyControl, disabled} = @props
-    if prevProps.keyControl? and (disabled or not keyControl?)
+    {keyControl} = @props
+
+    if @shouldKey(prevProps) and not @shouldKey()
       keysHelper.off(prevProps.keyControl, 'multiple-choice')
 
-    if keyControl? and not disabled and prevProps.keyControl isnt keyControl
+    if @shouldKey() and prevProps.keyControl isnt keyControl
       @setUpKeys()
 
-  setUpKeys: ->
-    {answer, onChangeAnswer, disabled, keyControl} = @props
+  shouldKey: (props) ->
+    props ?= @props
+    {keyControl, disabled} = props
 
-    if keyControl and not disabled
-      keyInAnswer = _.partial onChangeAnswer, answer
-      keysHelper.on keyControl, 'multiple-choice', keyInAnswer
-      keymaster.setScope('multiple-choice')
+    keyControl? and not disabled
+
+  setUpKeys: ->
+    {answer, onChangeAnswer, keyControl} = @props
+
+    keyInAnswer = _.partial onChangeAnswer, answer
+    keysHelper.on keyControl, 'multiple-choice', keyInAnswer
+    keymaster.setScope('multiple-choice')
 
   contextTypes:
     processHtmlAndMath: React.PropTypes.func


### PR DESCRIPTION
decreases the mounting and re-mounting of htmlandmath components with the same content within, decreasing the frequency with which mathjax rendering is called

Most noticeably, maths no long flashes between free-response to multiple-choice step for question
