### PR TITLE
Run newly created specs on `npm test`

### DIFF
--- a/test/all-tests.coffee
+++ b/test/all-tests.coffee
@@ -1,5 +1,2 @@
-{expect} = require 'chai'
-
-describe 'A stub test', ->
-  it 'should have a test', ->
-    expect(true).to.be.true
+testsContext = require.context("./", true, /\.spec\.(cjsx|coffee)$/)
+testsContext.keys().forEach(testsContext)


### PR DESCRIPTION
Oops.   The spec files weren't included so Travis wasn't running them.  I'd created them using `gulp tdd` which runs them in response to file changes, but that doesn't work for Travis (of course).
