### PR TITLE
free response and answer id should update as props do, and from user action

### DIFF
--- a/src/components/exercise/mode.cjsx
+++ b/src/components/exercise/mode.cjsx
@@ -31,13 +31,14 @@ ExMode = React.createClass
     @focusBox() if mode is 'free-response'
 
   componentWillReceiveProps: (nextProps) ->
-    {mode, free_response, answer_id} = nextProps
+    {free_response, answer_id} = nextProps
 
-    switch mode
-      when 'free-response'
-        @setState(freeResponse: free_response) if @state.freeResponse isnt free_response
-      when 'multiple-choice'
-        @setState(answerId: answer_id) if @state.answerId isnt answer_id
+    nextAnswers = {}
+
+    nextAnswers.freeResponse = free_response if @state.freeResponse isnt free_response
+    nextAnswers.answerId = answer_id if @state.answerId isnt answer_id
+
+    @setState(nextAnswers) unless _.isEmpty(nextAnswers)
 
   focusBox: ->
     {focus, mode} = @props


### PR DESCRIPTION
This was too strict and causing the `answerId` to keep the previous `answerId` when switching between questions in review mode.
