### PR TITLE
Extend past floated elements by using clearfix

### DIFF
--- a/resources/styles/components/pinned-header-footer-card/sections.less
+++ b/resources/styles/components/pinned-header-footer-card/sections.less
@@ -15,3 +15,6 @@
     .fixed-bar();
   }
 }
+
+// always wrap around elements by extending bootstrap's clearfix
+.card-body { &:extend(.clearfix all); }


### PR DESCRIPTION
#### Before:

![screen shot 2016-02-10 at 4 41 16 pm](https://cloud.githubusercontent.com/assets/79566/12964335/292aa7ba-d015-11e5-8ad5-e1e2e1e1c66b.png)
#### After:

![screen shot 2016-02-10 at 4 42 03 pm](https://cloud.githubusercontent.com/assets/79566/12964345/3c4689b8-d015-11e5-9f7b-eecb45c73756.png)
