### PR TITLE
allow pass through of props for controlText

### DIFF
--- a/src/components/exercise/props.cjsx
+++ b/src/components/exercise/props.cjsx
@@ -48,6 +48,7 @@ EXERCISE_STEP_CARD_PROP_TYPES.pinned = React.PropTypes.bool
 EXERCISE_STEP_CARD_PROP_TYPES.allowKeyNav = React.PropTypes.bool
 EXERCISE_STEP_CARD_PROP_TYPES.panel = React.PropTypes.oneOf(['review', 'multiple-choice', 'free-response', 'teacher-read-only'])
 EXERCISE_STEP_CARD_PROP_TYPES.review = React.PropTypes.string
+EXERCISE_STEP_CARD_PROP_TYPES.controlText = React.PropTypes.string
 
 EXERCISE_STEP_CARD_PROP_TYPES.onAnswerChanged = React.PropTypes.func
 EXERCISE_STEP_CARD_PROP_TYPES.onFreeResponseChange = React.PropTypes.func

--- a/src/components/exercise/step-card.cjsx
+++ b/src/components/exercise/step-card.cjsx
@@ -116,12 +116,12 @@ ExerciseStepCard = React.createClass
       onNextStep() unless canReview
 
   render: ->
-    {step, panel, pinned, isContinueEnabled, waitingText, controlButtons, className, footer} = @props
+    {step, panel, pinned, isContinueEnabled, waitingText, controlButtons, controlText, className, footer} = @props
     {group, related_content} = step
 
     ControlButtons = CONTROLS[panel]
     onInputChange = ON_CHANGE[panel]
-    controlText = CONTROLS_TEXT[panel]
+    controlText ?= CONTROLS_TEXT[panel]
 
     controlProps = _.pick(@props, props.ExReviewControls)
     controlProps.isContinueEnabled = isContinueEnabled and @isContinueEnabled(@props, @state)


### PR DESCRIPTION
Control text should be customizable externally, see also openstax/tutor-js#991
