### PR TITLE
Fix/free response cache and continue button

### DIFF
--- a/src/components/exercise/mode.cjsx
+++ b/src/components/exercise/mode.cjsx
@@ -31,11 +31,12 @@ ExMode = React.createClass
     @focusBox() if mode is 'free-response'
 
   componentWillReceiveProps: (nextProps) ->
-    {free_response, answer_id} = nextProps
+    {free_response, answer_id, freeResponseValue} = nextProps
 
     nextAnswers = {}
+    freeResponse = free_response or freeResponseValue or ''
 
-    nextAnswers.freeResponse = free_response if @state.freeResponse isnt free_response
+    nextAnswers.freeResponse = freeResponse if @state.freeResponse isnt freeResponse
     nextAnswers.answerId = answer_id if @state.answerId isnt answer_id
 
     @setState(nextAnswers) unless _.isEmpty(nextAnswers)
@@ -55,9 +56,8 @@ ExMode = React.createClass
     @props.onAnswerChanged?(answer)
 
   getFreeResponse: ->
-    freeResponseValue = @state.freeResponse
     {mode, free_response, disabled} = @props
-    {freeResponseValue} = @props unless freeResponseValue
+    {freeResponse} = @state
 
 
     if mode is 'free-response'
@@ -65,7 +65,7 @@ ExMode = React.createClass
         disabled={disabled}
         ref='freeResponse'
         placeholder='Enter your response'
-        value={freeResponseValue or ''}
+        value={freeResponse}
         onChange={@onFreeResponseChange}
       />
     else

--- a/src/components/exercise/step-card.cjsx
+++ b/src/components/exercise/step-card.cjsx
@@ -81,7 +81,7 @@ ExerciseStepCard = React.createClass
 
   getStepState: (props) ->
     {step} = props
-    freeResponse: step.free_response or ''
+    freeResponse: step.free_response or props.freeResponseValue or ''
     answerId: step.answer_id or ''
 
   isContinueEnabled: (props, state) ->

--- a/src/components/exercise/step-card.cjsx
+++ b/src/components/exercise/step-card.cjsx
@@ -61,7 +61,7 @@ ExerciseStepCard = React.createClass
       @isContinueEnabled(@props, @state) is @isContinueEnabled(nextProps, nextState))
 
   componentWillReceiveProps: (nextProps) ->
-    unless _.isEqual(@getStepState(@props), @getStepState(nextProps))
+    unless _.isEqual(@getStepState(@props, @state), @getStepState(nextProps))
       nextStepState = @getStepState(nextProps)
       @setState(nextStepState)
 
@@ -79,9 +79,10 @@ ExerciseStepCard = React.createClass
     keymaster.unbind('enter', 'multiple-choice')
     keymaster.deleteScope('multiple-choice')
 
-  getStepState: (props) ->
+  getStepState: (props, state = {}) ->
+    {freeResponse} = state
     {step} = props
-    freeResponse: step.free_response or props.freeResponseValue or ''
+    freeResponse: step.free_response or props.freeResponseValue or freeResponse or ''
     answerId: step.answer_id or ''
 
   isContinueEnabled: (props, state) ->

--- a/src/components/question/answer.cjsx
+++ b/src/components/question/answer.cjsx
@@ -118,7 +118,7 @@ Answer = React.createClass
       </div>
 
     if @props.show_all_feedback and answer.feedback_html
-      feedback = <Feedback key='question-mc-feedback' children={answer.feedback_html} />
+      feedback = <Feedback key='question-mc-feedback'>{answer.feedback_html}</Feedback>
 
     htmlAndMathProps = _.pick(@context, 'processHtmlAndMath')
 


### PR DESCRIPTION
Ensures that the current free response state value is being checked for whether the `Continue` button will be enabled -- [ticket](https://www.pivotaltracker.com/story/show/115792951)

![fr-button](https://cloud.githubusercontent.com/assets/2483873/13887464/cc49b9d4-ed09-11e5-9954-854b374b457d.gif)
