### PR TITLE
Include font-awesome for the fa() mixin

### DIFF
--- a/resources/styles/components/exercise/preview.less
+++ b/resources/styles/components/exercise/preview.less
@@ -1,3 +1,5 @@
+@import "../../globals/font-awesome";
+
 &-exercise-preview {
 
   position: relative;


### PR DESCRIPTION
Concept coach isn't including the mixin, so it has an error when styles are built
