### PR TITLE
video embed was causing errors when iframe isnt the direct child of the HTML component

### DIFF
--- a/src/components/demo.cjsx
+++ b/src/components/demo.cjsx
@@ -20,6 +20,9 @@ exercisePreviewStub = require '../../stubs/exercise-preview/data'
 Breadcrumb = require './breadcrumb'
 breadcrumbStub = require '../../stubs/breadcrumbs/steps'
 
+ArbitraryHtmlAndMath = require './html'
+HTMLStub = require '../../stubs/html/data'
+
 getCurrentPanel = (stepId) ->
   step = steps[stepId]
   panel = 'free-response'
@@ -160,6 +163,11 @@ BreadcrumbDemo = React.createClass
       </div>
     </div>
 
+HTMLDemo = React.createClass
+  displayName: 'HTMLDemo'
+  render: ->
+    <ArbitraryHtmlAndMath {...HTMLStub} className='col-xs-6'/>
+
 Demo = React.createClass
   displayName: 'Demo'
   render: ->
@@ -167,6 +175,7 @@ Demo = React.createClass
       exercise: <ExerciseDemo/>
       exercisePreview: <ExercisePreviewDemo/>
       breadcrumbs: <BreadcrumbDemo/>
+      html: <HTMLDemo/>
 
     demos = _.map(demos, (demo, name) ->
       <BS.Row key={name} className='demo openstax-wrapper'>

--- a/src/components/html.cjsx
+++ b/src/components/html.cjsx
@@ -14,7 +14,7 @@ module.exports = React.createClass
     processHtmlAndMath: React.PropTypes.func
   getDefaultProps: ->
     block: false
-    excludeFrame: (frame) ->
+    shouldExcludeFrame: (frame) ->
       /cnx.org\/specials\//.test(frame.src)
 
   render: ->
@@ -59,4 +59,4 @@ module.exports = React.createClass
     _.each links, (link) ->
       link.setAttribute('target', '_blank') unless link.getAttribute('href')?[0] is '#'
     @props.processHtmlAndMath?(root) or typesetMath(root)
-    wrapFrames(root, @props.excludeFrame)
+    wrapFrames(root, @props.shouldExcludeFrame)

--- a/src/components/html.cjsx
+++ b/src/components/html.cjsx
@@ -14,6 +14,8 @@ module.exports = React.createClass
     processHtmlAndMath: React.PropTypes.func
   getDefaultProps: ->
     block: false
+    excludeFrame: (frame) ->
+      /cnx.org\/specials\//.test(frame.src)
 
   render: ->
     {className, block} = @props
@@ -57,4 +59,4 @@ module.exports = React.createClass
     _.each links, (link) ->
       link.setAttribute('target', '_blank') unless link.getAttribute('href')?[0] is '#'
     @props.processHtmlAndMath?(root) or typesetMath(root)
-    wrapFrames(root)
+    wrapFrames(root, @props.excludeFrame)

--- a/src/helpers/html-videos.coffee
+++ b/src/helpers/html-videos.coffee
@@ -10,11 +10,12 @@ getRatioClass = (frame) ->
   else
     return "embed-responsive-16by9"
 
+isEmbedded = (frame) ->
+  frame.parentNode?.classList.contains('embed-responsive')
 
-wrapFrames = (dom, excludeFrame) ->
+wrapFrames = (dom, shouldExcludeFrame) ->
   _.each(dom.getElementsByTagName('iframe'), (frame) ->
-    if (frame.parentNode?.classList.contains('embed-responsive')) then return
-    if (excludeFrame(frame)) then return
+    return null if isEmbedded(frame) or shouldExcludeFrame?(frame)
 
     wrapper = document.createElement("div")
     wrapper.className = "frame-wrapper embed-responsive #{getRatioClass(frame)}"

--- a/src/helpers/html-videos.coffee
+++ b/src/helpers/html-videos.coffee
@@ -17,7 +17,7 @@ wrapFrames = (dom) ->
 
     wrapper = document.createElement("div")
     wrapper.className = "frame-wrapper embed-responsive #{getRatioClass(frame)}"
-    dom.replaceChild(wrapper, frame)
+    frame.parentNode.replaceChild(wrapper, frame)
     wrapper.appendChild(frame)
   )
 

--- a/src/helpers/html-videos.coffee
+++ b/src/helpers/html-videos.coffee
@@ -11,10 +11,10 @@ getRatioClass = (frame) ->
     return "embed-responsive-16by9"
 
 
-wrapFrames = (dom) ->
+wrapFrames = (dom, excludeFrame) ->
   _.each(dom.getElementsByTagName('iframe'), (frame) ->
     if (frame.parentNode?.classList.contains('embed-responsive')) then return
-    if (/cnx.org\/specials\//.test(frame.src)) then return
+    if (excludeFrame(frame)) then return
 
     wrapper = document.createElement("div")
     wrapper.className = "frame-wrapper embed-responsive #{getRatioClass(frame)}"

--- a/src/helpers/html-videos.coffee
+++ b/src/helpers/html-videos.coffee
@@ -14,6 +14,7 @@ getRatioClass = (frame) ->
 wrapFrames = (dom) ->
   _.each(dom.getElementsByTagName('iframe'), (frame) ->
     if (frame.parentNode?.classList.contains('embed-responsive')) then return
+    if (/cnx.org\/specials\//.test(frame.src)) then return
 
     wrapper = document.createElement("div")
     wrapper.className = "frame-wrapper embed-responsive #{getRatioClass(frame)}"

--- a/stubs/html/data.json
+++ b/stubs/html/data.json
@@ -1,0 +1,3 @@
+{
+  "html": "<iframe width='560' height='315' src='https://www.youtube.com/embed/oq5gaV4ohn4' frameborder='0' allowfullscreen></iframe><div><iframe width='560' height='315' src='https://www.youtube.com/embed/-m3V8w_7vhk' frameborder='0' allowfullscreen></iframe></div><div class='embed-responsive embed-responsive-16by9'><iframe width='560' height='315' src='https://www.youtube.com/embed/y5mt4KBoQnc' frameborder='0' allowfullscreen></iframe></div><iframe width='960' height='560' src='https://archive.cnx.org/specials/e2ca52af-8c6b-450e-ac2f-9300b38e8739/moving-man/' frameborder='0' allowfullscreen></iframe>"
+}

--- a/test/components/html.spec.coffee
+++ b/test/components/html.spec.coffee
@@ -18,6 +18,20 @@ describe 'Arbitrary Html Component', ->
       processHtmlAndMath: sinon.spy()
       block: true
 
+    @nestedFrameProps =
+      className: 'html'
+      html: """<div><iframe width="560" height="315" src="https://www.youtube.com/embed/BINK6r1Wy78"
+      frameborder="0" allowfullscreen></iframe></div>"""
+      processHtmlAndMath: sinon.spy()
+      block: true
+
+    @simsFrameProps =
+      className: 'html'
+      html: """<iframe width="560" height="315" src="https://archive.cnx.org/specials/e2ca52af-8c6b-450e-ac2f-9300b38e8739/moving-man/"
+      frameborder="0" allowfullscreen></iframe>"""
+      processHtmlAndMath: sinon.spy()
+      block: true
+
   it 'renders html', ->
     Testing.renderComponent( Html, props: @props ).then ({dom}) ->
       expect(dom.tagName).equal('DIV')
@@ -35,3 +49,11 @@ describe 'Arbitrary Html Component', ->
   it 'wraps iframes with embed classes', ->
     Testing.renderComponent( Html, props: @frameProps ).then ({dom}) ->
       expect(dom.getElementsByClassName('embed-responsive').length).equal(1)
+
+  it 'wraps nested iframes with embed classes', ->
+    Testing.renderComponent( Html, props: @nestedFrameProps ).then ({dom}) ->
+      expect(dom.getElementsByClassName('embed-responsive').length).equal(1)
+
+  it 'ignores iframes with sim link', ->
+    Testing.renderComponent( Html, props: @simsFrameProps ).then ({dom}) ->
+      expect(dom.getElementsByClassName('embed-responsive').length).equal(0)

--- a/test/helpers/html-videos.coffee
+++ b/test/helpers/html-videos.coffee
@@ -31,6 +31,17 @@ describe 'Html Video Helper', ->
     dom = HtmlVideo.wrapFrames(dom)
     expect(dom.getElementsByClassName('embed-responsive').length).to.equal(1)
 
+  it 'can wrap html videos frame even if nested', ->
+    dom = document.createElement('div')
+    html = """<div><div><iframe width="560" height="315" src="https://www.youtube.com/embed/BINK6r1Wy78"
+    frameborder="0" allowfullscreen></iframe></div></div>
+    <iframe width="560" height="315" src="https://www.youtube.com/embed/BINK6r1Wy78"
+    frameborder="0" allowfullscreen></iframe>"""
+
+    dom.innerHTML = html
+    dom = HtmlVideo.wrapFrames(dom)
+    expect(dom.getElementsByClassName('embed-responsive').length).to.equal(2)
+
   it 'can add responsive embed classes with correct aspect ratio', ->
     dom = document.createElement('div')
 


### PR DESCRIPTION
to fix the dom js error about wrapping iframes with responsive parents:

![screen shot 2016-04-18 at 1 29 36 pm](https://cloud.githubusercontent.com/assets/2483873/14617485/0a7806c0-0574-11e6-9689-58971772364b.png)
