### PR TITLE
per isWaiting toggle for async button,the delay should only ever be set once

### DIFF
--- a/src/components/buttons/async-button.cjsx
+++ b/src/components/buttons/async-button.cjsx
@@ -20,19 +20,29 @@ module.exports = React.createClass
 
   getInitialState: ->
     isTimedout: false
+    delayTimeout: null
+
+  componentWillReceiveProps: (nextProps) ->
+    if @props.isWaiting isnt nextProps.isWaiting
+      @clearDelay() unless nextProps.isWaiting
+      @setState(delayTimeout: null)
 
   componentDidUpdate: ->
     {isWaiting, isJob} = @props
-    {isTimedout} = @state
+    {isTimedout, delayTimeout} = @state
 
-    timeout = @props.timeoutLength or if isJob then 600000 else 30000
-
-    if isWaiting and not isTimedout
-      _.delay @checkForTimeout, timeout
+    if not delayTimeout and isWaiting and not isTimedout
+      timeout = @props.timeoutLength or if isJob then 600000 else 30000
+      delayTimeout = _.delay @checkForTimeout, timeout
+      @setState({delayTimeout})
 
   checkForTimeout: ->
     {isWaiting} = @props
-    @setState(isTimedout: true) if isWaiting and @isMounted()
+    @setState(isTimedout: true, delayTimeout: null) if isWaiting and @isMounted()
+
+  clearDelay: ->
+    {delayTimeout} = @state
+    clearTimeout(delayTimeout)
 
   getDefaultProps: ->
     isDone: false


### PR DESCRIPTION
**Not based off master**

Based off the `openstax-react-components` that is installed on production [#d-20160418.frame-embed-candidate-a](https://github.com/openstax/react-components/releases/tag/d-20160418.frame-embed-candidate-a)

also, when no longer waiting, clear the delay that would be checking a future timeout
