### PR TITLE
Style fixes for notifications / email verification

### DIFF
--- a/resources/styles/components/notifications-bar.less
+++ b/resources/styles/components/notifications-bar.less
@@ -3,7 +3,7 @@
   left: 0;
   right: 0;
   background-color: @openstax-primary;
-  padding-left: 4rem;
+
   .notification {
     .flex-display();
     .flex-direction(row);
@@ -17,10 +17,9 @@
     .body, .error {
       .flex-display();
       .flex-direction(row);
-      .justify-content(flex-start);
+      .justify-content(center);
       .align-items(center);
       .message {
-        .flex(1);
         text-align: right;
       }
     }
@@ -36,23 +35,25 @@
       margin-right: 1rem;
       font-size: 3rem;
     }
-
-    .action {
+    .dismiss, .action {
       color: @openstax-neutral-lighter;
       cursor: pointer;
-      font-size: 1.8rem;
+      text-decoration: none;
       margin-left: 1rem;
-    }
-    &.email {
-      .action:hover {
-        text-decoration: none;
+      &:hover {
+        text-decoration: underline;
         color: @openstax-neutral-light;
         border-color: @openstax-neutral-light;
       }
+    }
+    .dismiss {
+      font-size: 1.5rem;
+    }
+    .action {
+      font-size: 1.8rem;
+    }
+    &.email {
 
-      &.verify {
-        .action { text-decoration: underline; }
-      }
 
       input {
         width: 10rem;
@@ -66,9 +67,7 @@
         padding: 4px;
         width: 60px;
         text-align: center;
-
       }
-
     }
   }
 }

--- a/src/components/notifications/email.cjsx
+++ b/src/components/notifications/email.cjsx
@@ -46,6 +46,7 @@ EmailNotification = React.createClass
 
   renderStart: ->
     <span className="body">
+      <i className='icon fa fa-envelope-o' />
       Verifying your email address allows you to recover your password if you ever forget it.
       <a className='action' onClick={@onVerify}>Verify now</a>
     </span>
@@ -58,6 +59,7 @@ EmailNotification = React.createClass
     _.defer =>
       @refs.verifyInput?.getInputDOMNode().focus()
     <span className="body verify">
+      <i className='icon fa fa-envelope-o' />
       <span className="message">
         Check your email inbox. Enter the 6-digit verification code:
       </span>
@@ -74,9 +76,13 @@ EmailNotification = React.createClass
 
   renderSuccess: ->
     <span className="body">
+      <i className='icon fa fa-envelope-o' />
       <span className="message">Verification was successful!</span>
     </span>
 
+  onDismiss: ->
+    Notifications.acknowledge(@props.notice)
+    undefined # silence react warning about return value
 
   onSuccess: ->
     # wait a bit so the "Success" message is seen, then hide
@@ -109,9 +115,9 @@ EmailNotification = React.createClass
       {'with-error': @props.notice.error}
     )
     <div className={classNames}>
-      <i className='icon fa fa-envelope-o' />
       {error}
       {body}
+      <a className='dismiss' onClick={@onDismiss}>Dismiss</a>
     </div>
 
 

--- a/src/components/notifications/system.cjsx
+++ b/src/components/notifications/system.cjsx
@@ -14,10 +14,12 @@ SystemNotification = React.createClass
     undefined # silence React warning about return value
 
   render: ->
-    <div className="notification">
-      <i className='icon fa fa-info-circle' />
-      {@props.notice.message}
-      <a className='action' onClick={@acknowledge}>Dismiss</a>
+    <div className="notification system">
+      <span className="body">
+        <i className='icon fa fa-info-circle' />
+        {@props.notice.message}
+      </span>
+      <a className='dismiss' onClick={@acknowledge}>Dismiss</a>
     </div>
 
 module.exports = SystemNotification

--- a/test/components/notifications/email.spec.coffee
+++ b/test/components/notifications/email.spec.coffee
@@ -2,7 +2,7 @@
 
 EmailNotification = require 'components/notifications/email'
 
-describe 'System Notifications', ->
+describe 'Email Notifications', ->
 
   beforeEach ->
     @props =

--- a/test/components/notifications/system.spec.coffee
+++ b/test/components/notifications/system.spec.coffee
@@ -18,5 +18,5 @@ describe 'System Notifications', ->
 
   it 'remembers notice as ignored when dismiss is clicked', ->
     Testing.renderComponent( SystemNotifications, props: @props ).then ({dom}) =>
-      Testing.actions.click(dom.querySelector('.action'))
+      Testing.actions.click(dom.querySelector('.dismiss'))
       expect(Notifications.acknowledge).to.have.been.calledWith(@props.notice)


### PR DESCRIPTION
@openstax/ux to review, I'm unsure if the system notification should be center aligned like the email is or should it be to the left?

<img width="1188" alt="screen shot 2016-05-06 at 5 20 14 pm" src="https://cloud.githubusercontent.com/assets/79566/15087504/d4772c42-13ae-11e6-9745-69a8561dc181.png">
