### PR TITLE
Display exercise "context" if present

### DIFF
--- a/src/components/exercise/mode.cjsx
+++ b/src/components/exercise/mode.cjsx
@@ -82,7 +82,7 @@ ExMode = React.createClass
 
     questionProperties = [
       'processHtmlAndMath', 'choicesEnabled', 'correct_answer_id',
-      'feedback_html', 'type', 'questionNumber', 'project'
+      'feedback_html', 'type', 'questionNumber', 'project', 'context'
     ]
 
     questionProps = _.pick(@props, questionProperties)

--- a/src/components/question/index.cjsx
+++ b/src/components/question/index.cjsx
@@ -59,7 +59,7 @@ Question = React.createClass
     @hasAnswerCorrectness() and @doesArrayHaveProperty(collaborator_solutions, 'content_html')
 
   render: ->
-    {model, correct_answer_id, exercise_uid, className, questionNumber} = @props
+    {model, correct_answer_id, exercise_uid, className, questionNumber, context} = @props
     {stem_html, collaborator_solutions, formats, stimulus_html} = model
 
     hasCorrectAnswer = !! correct_answer_id
@@ -80,6 +80,7 @@ Question = React.createClass
         </div>
 
     <div className={classes} data-question-number={questionNumber}>
+      <QuestionHtml type='context' html={context} />
       <QuestionHtml type='stimulus' html={stimulus_html} />
       <QuestionHtml type='stem' html={stem_html} />
       {@props.children}

--- a/stubs/exercise-multipart/steps.js
+++ b/stubs/exercise-multipart/steps.js
@@ -2,6 +2,7 @@ var steps = [{ "id": "step-id-9-1",
     "type": "exercise",
     "correct_answer_id": "id2",
     "is_in_multipart": true,
+    "context": "Mathematics is an old, broad, and deep discipline (field of study). People working to improve math education need to understand <b>\"What is Mathematics?\"</b>",
     "content": {
       "questions":[
         {

--- a/test/components/exercise/step-data.json
+++ b/test/components/exercise/step-data.json
@@ -15,6 +15,7 @@
   ],
   "labels": [],
   "content_url": "https://exercises-qa.openstax.org/exercises/6690@1",
+  "context": "Water is very important for life. We need water to drink, to wash our hands, to cook, to water plants and many other things.",
   "content": {
     "uid": "6690@1",
     "number": 6690,

--- a/test/components/question/index.spec.coffee
+++ b/test/components/question/index.spec.coffee
@@ -27,3 +27,8 @@ describe 'Question Component', ->
         expect(@props.onChange).to.have.been.called
         expect(answer.classList.contains('answer-checked')).to.be.true
         done()
+
+  it 'renders the context when given', ->
+    @props.context = STEP.context
+    Testing.renderComponent( Question, props: @props ).then ({dom}) ->
+      expect(dom.querySelector('.question-context').textContent).to.have.string('Water is very important for life')


### PR DESCRIPTION
Some exercises need to display "context" from the associated readings
along so it can be referred to while answering the question

![screen shot 2016-06-07 at 4 33 56 pm](https://cloud.githubusercontent.com/assets/79566/15875488/be95b56e-2ccd-11e6-91b2-67ff861fd513.png)
