### PR TITLE
switch to display: block for IE

### DIFF
--- a/resources/styles/components/exercise-preview/index.less
+++ b/resources/styles/components/exercise-preview/index.less
@@ -60,11 +60,7 @@
       .transition(all .25s ease-in-out);
 
       .message {
-        display: flex;
-        flex-direction: row;
-        justify-content: center;
-        align-items: stretch;
-
+        display: block;
         font-size: 1.5rem;
         line-height: 1.5rem;
         font-weight: 700;
@@ -73,10 +69,7 @@
         .openstax-disable-text-select();
         .action {
           flex: 1;
-          display: flex;
-          flex-direction: column;
-          align-items: center;
-          justify-content: center;
+          display: inline-block;
           text-align: center;
           color: white;
           user-select:  none;

--- a/resources/styles/mixins/index.less
+++ b/resources/styles/mixins/index.less
@@ -104,6 +104,6 @@
     position: absolute;
     left: 0;
     top: @max-height - 150px;
-    background: linear-gradient(to top, white, white 10%, transparent);
+    background: linear-gradient(to top, white, white 10%, rgba(255,255,255,0));
   }
 }


### PR DESCRIPTION
flex isn't really needed for the alignment now that we're using SVG. Since IE has issues with it it's easiest to just use `block`

Also updates the gradient colors so the mask for too-tall elements appears correctly in Safari & IE
