### PR TITLE
Fix for changing instructions

### DIFF
--- a/src/components/question/answers-table.cjsx
+++ b/src/components/question/answers-table.cjsx
@@ -81,8 +81,14 @@ AnswersTable = React.createClass
       @props.onChangeAttempt?(answer)
 
   shouldInstructionsShow: ->
-    {type, model, hasCorrectAnswer} = @props
-    model.formats.length > 1 and not (hasCorrectAnswer or type in ['teacher-preview', 'teacher-review'])
+    {type, model, answer_id, correct_answer_id} = @props
+    (
+      model.formats.length > 1 and
+      not (
+        answer_id is correct_answer_id or
+        type in ['teacher-preview', 'teacher-review']
+      )
+    )
 
   hasIncorrectAnswer: ->
     {answer_id, correct_answer_id, choicesEnabled} = @props
@@ -125,6 +131,7 @@ AnswersTable = React.createClass
 
     instructions = <Instructions
       project={project}
+      hasFeedback={feedback_html?}
       hasIncorrectAnswer={@hasIncorrectAnswer()}
     /> if @shouldInstructionsShow()
 

--- a/src/components/question/instructions.cjsx
+++ b/src/components/question/instructions.cjsx
@@ -12,12 +12,16 @@ PROJECT_NAME_AND_FEEDBACK =
 
 Instructions = React.createClass
   displayName: 'Instructions'
+
   propTypes:
     project: React.PropTypes.oneOf _.keys(PROJECT_NAME_AND_FEEDBACK)
-  render: ->
-    {project, projectName, feedbackType, hasIncorrectAnswer } = @props
+    hasIncorrectAnswer: React.PropTypes.bool
+    hasFeedback: React.PropTypes.bool
 
-    if (hasIncorrectAnswer)
+  render: ->
+    {project, projectName, feedbackType, hasFeedback, hasIncorrectAnswer} = @props
+
+    if (hasIncorrectAnswer and hasFeedback)
       return <p className="instructions">
         Incorrect. Please review your feedback.
       </p>


### PR DESCRIPTION
Incorrect answer instructions were being shown for a second when changing answers.
Pivotal ticket: https://www.pivotaltracker.com/story/show/121524171

Before:
![change-answer](https://cloud.githubusercontent.com/assets/6434717/16273013/ec0de0e2-386d-11e6-86dd-3c4236e75f5e.gif)

After:
![change-answer-2](https://cloud.githubusercontent.com/assets/6434717/16273016/efd9e84c-386d-11e6-8cdd-50f7caf99d1c.gif)
