### PR TITLE
Remove position static, set control sizes

### DIFF
--- a/resources/styles/components/exercise-preview/index.less
+++ b/resources/styles/components/exercise-preview/index.less
@@ -1,6 +1,8 @@
 &-exercise-preview {
   position: relative;
-  @action-square-size: 150px;
+  @action-square-width: 140px;
+  @action-square-height: 130px;
+
   @action-icon-circle-size: 80px;
 
   .sans(@size: 1.5rem, @line-height: 3rem) {
@@ -68,17 +70,23 @@
         .transition(all .25s ease-in-out);
         .openstax-disable-text-select();
         .action {
-          flex: 1;
           display: inline-block;
           text-align: center;
           color: white;
           user-select:  none;
-          width: @action-square-size;
-          height: @action-square-size;
+          width: @action-square-width;
+          height: @action-square-height;
           &:hover { box-shadow: 0 0 5px rgba(0,0,0,0.5); }
 
           &:before {
             .fa-icon();
+            content: "";
+            display: block;
+            margin: 10% auto;
+            background-repeat: no-repeat;
+            background-size: 100%;
+            padding-top: 0;
+            margin-bottom: 5px;
             font-weight: 300;
             text-align: center;
             background-color: white;
@@ -86,8 +94,6 @@
             border-radius: @action-icon-circle-size / 2;
             width: @action-icon-circle-size;
             height: @action-icon-circle-size;
-            padding-top: 12px;
-            margin-bottom: 8px;
           }
         }
       }
@@ -96,14 +102,16 @@
 
 
   &.actions-on-side {
-    @size-scale: 0.45;
+    @action-square-width: 67px;
+    @action-square-height: 75px;
+    @size-scale: 0.5;
     .panel-body, .panel-body:hover {
       padding-left: 90px;
       position: relative;
       .controls-overlay {
         visibility: visible;
         right: inherit;
-        width: @action-square-size * @size-scale;
+        width: @action-square-width;
         background-color: transparent;
         pointer-events: none;
         .message { opacity: 1; }
@@ -112,8 +120,8 @@
         pointer-events: all;
         flex-direction: column;
         .action {
-          height: @action-square-size * @size-scale;
-          width:  @action-square-size * @size-scale;
+          height: @action-square-height;
+          width:  @action-square-width;
           font-size: 12px;
           line-height: 12px;
           &:before {
@@ -150,7 +158,6 @@
       line-height: 1.4em;
     }
     .question-stem {
-      position: static;
       font-weight: 700;
       margin-bottom: 1rem;
       font-size: 1.6rem;


### PR DESCRIPTION
somewhat goes along with https://github.com/openstax/tutor-js/pull/1101 (that PR pulls this in)

`position:static` is throwing off the bottom mask.  Was only needed because of chrome bug where `position: relative` doesn't display correctly in column layouts.  That bug is fixed in latest chrome so shouldn't be an issue if people are up-to-date

https://bugs.chromium.org/p/chromium/issues/detail?id=527709
