### PR TITLE
Removing logic for determining interactive status based off of URL.

### DIFF
--- a/src/components/html.cjsx
+++ b/src/components/html.cjsx
@@ -14,8 +14,7 @@ module.exports = React.createClass
     processHtmlAndMath: React.PropTypes.func
   getDefaultProps: ->
     block: false
-    shouldExcludeFrame: (frame) ->
-      /cnx.org\/specials\//.test(frame.src)
+    shouldExcludeFrame: (frame) -> false
 
   render: ->
     {className, block} = @props

--- a/test/components/html.spec.coffee
+++ b/test/components/html.spec.coffee
@@ -25,13 +25,6 @@ describe 'Arbitrary Html Component', ->
       processHtmlAndMath: sinon.spy()
       block: true
 
-    @simsFrameProps =
-      className: 'html'
-      html: """<iframe width="560" height="315" src="https://archive.cnx.org/specials/e2ca52af-8c6b-450e-ac2f-9300b38e8739/moving-man/"
-      frameborder="0" allowfullscreen></iframe>"""
-      processHtmlAndMath: sinon.spy()
-      block: true
-
   it 'renders html', ->
     Testing.renderComponent( Html, props: @props ).then ({dom}) ->
       expect(dom.tagName).equal('DIV')
@@ -53,7 +46,3 @@ describe 'Arbitrary Html Component', ->
   it 'wraps nested iframes with embed classes', ->
     Testing.renderComponent( Html, props: @nestedFrameProps ).then ({dom}) ->
       expect(dom.getElementsByClassName('embed-responsive').length).equal(1)
-
-  it 'ignores iframes with sim link', ->
-    Testing.renderComponent( Html, props: @simsFrameProps ).then ({dom}) ->
-      expect(dom.getElementsByClassName('embed-responsive').length).equal(0)


### PR DESCRIPTION
Removes the default functionality where it tries to determine whether something should be wrapped in a frame based on where the content is coming from.

This PR goes hand-in-hand with one in tutor-js.
