### PR TITLE
Fixed missing exercise id and report problem link

### DIFF
--- a/src/components/exercise-identifier-link.cjsx
+++ b/src/components/exercise-identifier-link.cjsx
@@ -11,11 +11,6 @@ ExerciseIdentifierLink = React.createClass
     bookUUID: React.PropTypes.string
     exerciseId: React.PropTypes.string.isRequired
     project: React.PropTypes.oneOf(['concept-coach', 'tutor'])
-    related_content: React.PropTypes.array.isRequired
-
-  buildLabel: (related) ->
-    chapterSection = @sectionFormat(related.chapter_section, @props.sectionSeparator)
-    "Comes from #{chapterSection} - #{related.title}"
 
   render: ->
     url = Exercise.troubleUrl(@props)

--- a/src/components/exercise-identifier-link.cjsx
+++ b/src/components/exercise-identifier-link.cjsx
@@ -23,8 +23,5 @@ ExerciseIdentifierLink = React.createClass
       <span className='exercise-identifier-link'>
         ID# {@props.exerciseId} | <a target="_blank" href={url}>Report an error</a>
       </span>
-      <p>
-        { _.map(@props.related_content, @buildLabel) }
-      </p>
     </div>
 module.exports = ExerciseIdentifierLink

--- a/src/components/exercise/index.cjsx
+++ b/src/components/exercise/index.cjsx
@@ -53,6 +53,7 @@ ExerciseMixin =
 
     partProps =
       footer: footer
+      idLink: @renderIdLink()
       focus: true
       includeGroup: true
 
@@ -175,7 +176,6 @@ Exercise = React.createClass
     if @isSinglePart()
       return <CardBody footer={footer} className='openstax-multipart-exercise-card'>
         { @renderSinglePart() }
-        { @renderIdLink() }
       </CardBody>
 
     exerciseParts = @renderMultiParts()

--- a/src/components/exercise/part-card.cjsx
+++ b/src/components/exercise/part-card.cjsx
@@ -113,7 +113,8 @@ ExerciseStepCard = React.createClass
       waitingText,
       className,
       includeFooter,
-      includeGroup
+      includeGroup,
+      idLink
     } = @props
 
     {group, related_content} = step
@@ -151,6 +152,7 @@ ExerciseStepCard = React.createClass
           mode={panel}/>
       </div>
       {helpLink}
+      {idLink}
     </CardBody>
 
 module.exports = ExerciseStepCard

--- a/src/components/exercise/part.cjsx
+++ b/src/components/exercise/part.cjsx
@@ -39,6 +39,8 @@ ExercisePart = React.createClass
     canReview: React.PropTypes.bool
     disabled: React.PropTypes.bool
 
+    idLink: React.PropTypes.func
+
   getInitialState: ->
     {id} = @props
 


### PR DESCRIPTION
Adds in the exercise uid and report help link back into the card body for exercises, works for both single exercises and multipart exercises.

Pivotal: https://www.pivotaltracker.com/story/show/121524963

Single exercise:
![screen shot 2016-06-30 at 11 43 08 am](https://cloud.githubusercontent.com/assets/6434717/16494622/f857dc0e-3eb7-11e6-86cc-e52ee57dbb21.png)

Multipart:
![screen shot 2016-06-30 at 11 12 27 am](https://cloud.githubusercontent.com/assets/6434717/16494544/ba35c710-3eb7-11e6-9793-541bcc89b375.png)
