### PR TITLE
Safari Exercise Preview

### DIFF
--- a/resources/styles/components/exercise-preview/index.less
+++ b/resources/styles/components/exercise-preview/index.less
@@ -189,7 +189,7 @@
 
         .answer-label {
           font-weight: 400;
-          display: table;
+          display: block;
         }
 
         .answer-letter {
@@ -202,7 +202,6 @@
         }
 
         .answer-answer {
-          display: table;
           margin-bottom: 5px;
         }
       }

--- a/resources/styles/components/exercise-preview/index.less
+++ b/resources/styles/components/exercise-preview/index.less
@@ -173,6 +173,7 @@
       .answers-answer {
         padding-left: 15px;
         counter-increment: answer;
+        display: table;
 
         &.answer-correct {
           color: @openstax-secondary;
@@ -180,29 +181,29 @@
 
           &:before {
             .fa-icon();
-            float: left;
-            margin-top: 0.15em;
-            margin-right: .125em;
+            padding-top: 0.15em;
+            padding-right: .125em;
             content: @fa-var-check;
+            display: table-cell;
           }
         }
 
         .answer-label {
           font-weight: 400;
-          display: block;
+          display: table-cell;
         }
 
         .answer-letter {
-          margin-right: 1rem;
-          float: left;
-
+          padding-right: 1rem;
+          display: table-cell;
           &:after {
             content: counter(answer, lower-latin) ')';
           }
         }
 
         .answer-answer {
-          margin-bottom: 5px;
+          display: table-cell;
+          padding-bottom: 5px;
         }
       }
 


### PR DESCRIPTION
Fix for exercises preview in safari.

Pivotal ticket: https://www.pivotaltracker.com/story/show/123940081

I think previously, we had inconsistent layout with `display:table` rules, and safari was displaying it differently from other browsers.

![screen shot 2016-07-05 at 12 09 09 pm](https://cloud.githubusercontent.com/assets/6434717/16591318/625e60ce-42a9-11e6-86ed-1cb41eb058a4.png)
![screen shot 2016-07-05 at 12 08 56 pm](https://cloud.githubusercontent.com/assets/6434717/16591319/625e7e24-42a9-11e6-8d19-8aa893282b69.png)
![screen shot 2016-07-05 at 12 08 51 pm](https://cloud.githubusercontent.com/assets/6434717/16591320/645e4a92-42a9-11e6-87ff-82281f76158f.png)
