### PR TITLE
Fix scrolling with MPQ

### DIFF
--- a/index.cjsx
+++ b/index.cjsx
@@ -19,6 +19,7 @@ module.exports = {
 
   FreeResponse:           require './src/components/exercise/free-response'
   GetPositionMixin:       require './src/components/get-position-mixin'
+  ScrollToMixin:          require './src/components/scroll-to-mixin'
   KeysHelper:             require './src/helpers/keys'
   NotificationActions:    require './src/model/notifications'
   NotificationsBar:       require './src/components/notifications/bar'

--- a/package.json
+++ b/package.json
@@ -82,7 +82,6 @@
     "react-bootstrap": ">=0.23.0 <=0.26.2",
     "react-hot-loader": "1.3.0",
     "react-scroll-components": "0.2.2",
-    "react-waypoint": "openstax/react-waypoint#b34b248947feb0b0ebf89fcef6f234f60f3e516c",
     "selenium-webdriver": "2.47.0",
     "sinon": "1.17.1",
     "sinon-chai": "2.8.0",

--- a/src/components/demo.cjsx
+++ b/src/components/demo.cjsx
@@ -103,10 +103,6 @@ ExerciseDemo = React.createClass
   getInitialState: ->
     exerciseProps: getProps(SINGLEPART_STEP_IDS)
   getDefaultProps: ->
-    setScrollState: ->
-      console.info('scrolling', arguments)
-      {key} = scrollState
-      @setState(currentStep: key)
     goToStep: ->
       console.info('goToStep', arguments)
   update: ->
@@ -126,10 +122,6 @@ MultipartExerciseDemo = React.createClass
   getDefaultProps: ->
     goToStep: ->
       console.info('goToStep', arguments)
-    onPartLeave: ->
-      console.info('leaving', arguments)
-    onPartEnter: ->
-      console.info('entering', arguments)
   update: ->
     @setState(exerciseProps: getProps(MULTIPART_STEP_IDS))
   componentWillMount: ->
@@ -144,8 +136,6 @@ MultipartExerciseDemo = React.createClass
       {...exerciseProps}
       project='concept-coach'
       goToStep={goToStep}
-      onPartLeave={onPartLeave}
-      onPartEnter={onPartEnter}
       currentStep={currentStep}
       pinned={false}
     />

--- a/src/components/exercise/index.cjsx
+++ b/src/components/exercise/index.cjsx
@@ -1,5 +1,4 @@
 React = require 'react'
-Waypoint = require 'react-waypoint'
 _ = require 'underscore'
 
 ExercisePart = require './part'

--- a/src/components/exercise/index.cjsx
+++ b/src/components/exercise/index.cjsx
@@ -7,7 +7,7 @@ ExercisePart = require './part'
 ExerciseGroup = require './group'
 ExerciseBadges = require '../exercise-badges'
 ExerciseIdentifierLink = require '../exercise-identifier-link'
-ScrollTo = require '../scroll-to-mixin'
+ScrollToMixin = require '../scroll-to-mixin'
 
 ExerciseMixin =
   getLastPartId: ->
@@ -116,7 +116,7 @@ ExerciseMixin =
 
 ExerciseWithScroll = React.createClass
   displayName: 'ExerciseWithScroll'
-  mixins: [ExerciseMixin, ScrollTo]
+  mixins: [ExerciseMixin, ScrollToMixin]
 
   componentDidMount: ->
     {currentStep} = @props

--- a/src/components/exercise/index.cjsx
+++ b/src/components/exercise/index.cjsx
@@ -10,7 +10,7 @@ ExerciseBadges = require '../exercise-badges'
 ExerciseIdentifierLink = require '../exercise-identifier-link'
 
 {ScrollListenerMixin} = require 'react-scroll-components'
-{ScrollTracker, ScrollTrackerParentMixin} = require '../scroll-tracker'
+# {ScrollTracker, ScrollTrackerParentMixin} = require '../scroll-tracker'
 
 ExerciseMixin =
   getLastPartId: ->
@@ -152,17 +152,17 @@ ExerciseWithScroll = React.createClass
       return @renderSinglePart()
 
     exerciseParts = @renderMultiParts()
-    exercisePartsWithScroll = _.chain(exerciseParts)
-      .map _.partial(@wrapPartWithScroll, parts)
-      .flatten()
-      .value()
+    # exercisePartsWithScroll = _.chain(exerciseParts)
+    #   .map _.partial(@wrapPartWithScroll, parts)
+    #   .flatten()
+    #   .value()
     exerciseGroup = @renderGroup()
     footer ?= @renderFooter() if pinned
 
     <CardBody footer={footer} pinned={pinned} className='openstax-multipart-exercise-card'>
       <ExerciseBadges isMultipart={true}/>
       {exerciseGroup}
-      {exercisePartsWithScroll}
+      {exerciseParts}
       {@renderIdLink(false)}
     </CardBody>
 

--- a/src/components/exercise/index.cjsx
+++ b/src/components/exercise/index.cjsx
@@ -10,7 +10,7 @@ ExerciseBadges = require '../exercise-badges'
 ExerciseIdentifierLink = require '../exercise-identifier-link'
 
 {ScrollListenerMixin} = require 'react-scroll-components'
-# {ScrollTracker, ScrollTrackerParentMixin} = require '../scroll-tracker'
+{ScrollTracker, ScrollTrackerParentMixin} = require '../scroll-tracker'
 
 ExerciseMixin =
   getLastPartId: ->
@@ -152,17 +152,17 @@ ExerciseWithScroll = React.createClass
       return @renderSinglePart()
 
     exerciseParts = @renderMultiParts()
-    # exercisePartsWithScroll = _.chain(exerciseParts)
-    #   .map _.partial(@wrapPartWithScroll, parts)
-    #   .flatten()
-    #   .value()
+    exercisePartsWithScroll = _.chain(exerciseParts)
+      .map _.partial(@wrapPartWithScroll, parts)
+      .flatten()
+      .value()
     exerciseGroup = @renderGroup()
     footer ?= @renderFooter() if pinned
 
     <CardBody footer={footer} pinned={pinned} className='openstax-multipart-exercise-card'>
       <ExerciseBadges isMultipart={true}/>
       {exerciseGroup}
-      {exerciseParts}
+      {exercisePartsWithScroll}
       {@renderIdLink(false)}
     </CardBody>
 

--- a/src/components/exercise/index.cjsx
+++ b/src/components/exercise/index.cjsx
@@ -9,9 +9,6 @@ ExerciseGroup = require './group'
 ExerciseBadges = require '../exercise-badges'
 ExerciseIdentifierLink = require '../exercise-identifier-link'
 
-{ScrollListenerMixin} = require 'react-scroll-components'
-{ScrollTracker, ScrollTrackerParentMixin} = require '../scroll-tracker'
-
 ExerciseMixin =
   getLastPartId: ->
     {parts} = @props
@@ -119,31 +116,6 @@ ExerciseMixin =
 ExerciseWithScroll = React.createClass
   displayName: 'ExerciseWithScroll'
   mixins: [ExerciseMixin]
-  wrapPartWithScroll: (parts, exercisePart, index) ->
-    {onPartEnter, onPartLeave} = @props
-
-    part = parts[index]
-
-    scrollState =
-      key: part.stepIndex
-      questionNumber: part.questionNumber
-      id: part.id
-      index: index
-
-    onPartEnter = _.partial(onPartEnter, part.stepIndex) if onPartEnter and _.isFunction(onPartEnter)
-    onPartLeave = _.partial(onPartLeave, part.stepIndex) if onPartLeave and _.isFunction(onPartLeave)
-
-    marker = <div id="exercise-part-with-scroll-#{part.stepIndex}">
-      <Waypoint
-        key="exercise-part-with-scroll-#{part.stepIndex}"
-        onEnter={onPartEnter}
-        onLeave={onPartLeave}/>
-    </div>
-
-    [
-      marker,
-      exercisePart
-    ]
 
   render: ->
     {parts, footer, pinned} = @props
@@ -152,17 +124,14 @@ ExerciseWithScroll = React.createClass
       return @renderSinglePart()
 
     exerciseParts = @renderMultiParts()
-    exercisePartsWithScroll = _.chain(exerciseParts)
-      .map _.partial(@wrapPartWithScroll, parts)
-      .flatten()
-      .value()
+
     exerciseGroup = @renderGroup()
     footer ?= @renderFooter() if pinned
 
     <CardBody footer={footer} pinned={pinned} className='openstax-multipart-exercise-card'>
       <ExerciseBadges isMultipart={true}/>
       {exerciseGroup}
-      {exercisePartsWithScroll}
+      {exerciseParts}
       {@renderIdLink(false)}
     </CardBody>
 

--- a/src/components/exercise/index.cjsx
+++ b/src/components/exercise/index.cjsx
@@ -39,6 +39,7 @@ ExerciseMixin =
     <ExercisePart
       {...props}
       {...partProps}
+      focus={@isSinglePart()}
       step={part}
       id={part.id}
       taskId={part.task_id}/>
@@ -126,6 +127,9 @@ ExerciseWithScroll = React.createClass
     if nextProps.currentStep isnt @props.currentStep
       @scrollToSelector("[data-step='#{nextProps.currentStep}']")
 
+  onAfterScroll: ->
+    textArea = @_scrollingTargetDOM().querySelector("[data-step='#{@props.currentStep}'] textarea")
+    textArea?.focus()
 
   render: ->
     {parts, footer, pinned} = @props

--- a/src/components/exercise/mode.cjsx
+++ b/src/components/exercise/mode.cjsx
@@ -45,7 +45,7 @@ ExMode = React.createClass
 
   focusBox: ->
     {focus, mode} = @props
-    @refs.freeResponse?.getDOMNode?().focus?() if focus and mode is 'free-response'
+    # @refs.freeResponse?.getDOMNode?().focus?() if focus and mode is 'free-response'
 
   onFreeResponseChange: ->
     freeResponse = @refs.freeResponse?.getDOMNode()?.value

--- a/src/components/exercise/mode.cjsx
+++ b/src/components/exercise/mode.cjsx
@@ -24,6 +24,14 @@ ExMode = React.createClass
     freeResponse: free_response
     answerId: answer_id
 
+  componentDidMount: ->
+    {mode} = @props
+    @focusBox() if mode is 'free-response'
+
+  componentDidUpdate: (nextProps, nextState) ->
+    {mode} = nextProps
+    @focusBox() if mode is 'free-response'
+
   componentWillReceiveProps: (nextProps) ->
     {free_response, answer_id, cachedFreeResponse} = nextProps
 
@@ -34,6 +42,10 @@ ExMode = React.createClass
     nextAnswers.answerId = answer_id if @state.answerId isnt answer_id
 
     @setState(nextAnswers) unless _.isEmpty(nextAnswers)
+
+  focusBox: ->
+    {focus, mode} = @props
+    @refs.freeResponse?.getDOMNode?().focus?() if focus and mode is 'free-response'
 
   onFreeResponseChange: ->
     freeResponse = @refs.freeResponse?.getDOMNode()?.value

--- a/src/components/exercise/mode.cjsx
+++ b/src/components/exercise/mode.cjsx
@@ -45,7 +45,7 @@ ExMode = React.createClass
 
   focusBox: ->
     {focus, mode} = @props
-    # @refs.freeResponse?.getDOMNode?().focus?() if focus and mode is 'free-response'
+    @refs.freeResponse?.getDOMNode?().focus?() if focus and mode is 'free-response'
 
   onFreeResponseChange: ->
     freeResponse = @refs.freeResponse?.getDOMNode()?.value

--- a/src/components/exercise/mode.cjsx
+++ b/src/components/exercise/mode.cjsx
@@ -24,14 +24,6 @@ ExMode = React.createClass
     freeResponse: free_response
     answerId: answer_id
 
-  componentDidMount: ->
-    {mode} = @props
-    @focusBox() if mode is 'free-response'
-
-  componentDidUpdate: (nextProps, nextState) ->
-    {mode} = nextProps
-    @focusBox() if mode is 'free-response'
-
   componentWillReceiveProps: (nextProps) ->
     {free_response, answer_id, cachedFreeResponse} = nextProps
 
@@ -42,10 +34,6 @@ ExMode = React.createClass
     nextAnswers.answerId = answer_id if @state.answerId isnt answer_id
 
     @setState(nextAnswers) unless _.isEmpty(nextAnswers)
-
-  focusBox: ->
-    {focus, mode} = @props
-    @refs.freeResponse?.getDOMNode?().focus?() if focus and mode is 'free-response'
 
   onFreeResponseChange: ->
     freeResponse = @refs.freeResponse?.getDOMNode()?.value

--- a/src/components/exercise/part-card.cjsx
+++ b/src/components/exercise/part-card.cjsx
@@ -144,7 +144,7 @@ ExerciseStepCard = React.createClass
     cardClasses = classnames 'task-step', 'openstax-exercise-card', className
 
     <CardBody className={cardClasses} pinned={pinned} footer={footer}>
-      <div className="exercise-#{panel}">
+      <div className="exercise-#{panel}" data-step={@props.stepPartIndex}>
         {exerciseGroup}
         <ExMode
           {...step}

--- a/src/components/scroll-to-mixin.cjsx
+++ b/src/components/scroll-to-mixin.cjsx
@@ -1,0 +1,90 @@
+React = require 'react'
+_ = require 'underscore'
+
+# Note that the GetPositionMixin methods are called directly rather than mixing it in
+# since we're a mixin ourselves our consumers also include GetPosition and it causes
+# duplicate method name errors to mix it in
+GetPositionMixin = require './get-position-mixin'
+
+DEFAULT_DURATION   = 750 # milliseconds
+# This is calculated to be enough for the targeted element to fit under the top navbar
+# The navbar's height is controlled by the less variable @tutor-navbar-height from global/navbar.less
+DEFAULT_TOP_OFFSET = 80  # pixels
+
+# Attempt to scroll to element no more than this number of times.
+# In testing, no more than one attempt has been needed but it's best to have a failsafe to
+# ensure scrolling doesn't enter an infinite loop
+MAXIMUM_SCROLL_ATTEMPTS = 3
+
+# http://blog.greweb.fr/2012/02/bezier-curve-based-easing-functions-from-concept-to-implementation/
+EASE_IN_OUT = (t) ->
+  if t < .5 then 4 * t * t * t else (t - 1) * (2 * t - 2) * (2 * t - 2) + 1
+
+POSITION = (start, end, elapsed, duration) ->
+  return end if (elapsed > duration)
+  start + (end - start) * EASE_IN_OUT(elapsed / duration)
+
+ScrollToMixin =
+  getDefaultProps: ->
+    windowImpl: window
+
+  _scrollingTargetDOM: -> @scrollingTargetDOM?() or React.findDOMNode(@)
+
+  scrollToSelector: (selector, options) ->
+    return if _.isEmpty(selector)
+    options = _.extend({updateHistory: true}, options)
+
+    el = @_scrollingTargetDOM().querySelector(selector)
+    @scrollToElement(el, options) if el
+
+  _onBeforeScroll: (el) ->
+    el.classList.add('target-scroll')
+    @onBeforeScroll?(el)
+
+  _onAfterScroll: (el, options) ->
+    if el?.classList?.contains('target-scroll')
+      _.delay(el.classList.remove.bind(el.classList, 'target-scroll'), 150)
+    @props.windowImpl.history.pushState(null, null, "##{el.id}") if options.updateHistory
+    @onAfterScroll?(el)
+
+  _onScrollStep: (el, options) ->
+    # The element's postion may have changed if scrolling was initiated while
+    # the page was still being manipulated.
+    # If that's the case, we begin another scroll to it's current position
+    if options.attemptNumber < MAXIMUM_SCROLL_ATTEMPTS and @props.windowImpl.pageYOffset isnt @_desiredTopPosition(el)
+      @scrollToElement(el, options.attemptNumber + 1)
+    else
+      @_onAfterScroll(el, options)
+
+  _desiredTopPosition: (el) ->
+    GetPositionMixin.getTopPosition(el) - _.result(@, 'getScrollTopOffset', DEFAULT_TOP_OFFSET)
+
+  scrollToTop: ->
+    @scrollToSelector('#react-root-container')
+
+  scrollToElement: (el, options = {} ) ->
+    win       = @props.windowImpl
+    endPos    = @_desiredTopPosition(el)
+
+    if options.immediate is true
+      win.scroll(0, endPos)
+      return
+
+    startPos  = win.pageYOffset
+    startTime = Date.now()
+    duration  = _.result(@, 'getScrollDuration', DEFAULT_DURATION)
+    requestAnimationFrame = win.requestAnimationFrame or _.defer
+    options.attemptNumber ||= 0
+
+    step = =>
+      elapsed = Date.now() - startTime
+      win.scroll(0, POSITION(startPos, endPos, elapsed, duration) )
+      if elapsed < duration then requestAnimationFrame(step)
+      else @_onScrollStep(el, options)
+
+    @_onBeforeScroll(el)
+    step()
+
+
+
+module.exports = ScrollToMixin


### PR DESCRIPTION
The earlier code would focus on mount, which mean that each step would be rapidly focused, ending on the last.  When a box if focused, the window will also scroll, causing earlier steps to be skipped.

It would also trigger loads for each step as it scrolled, which do not seem to be needed so the waypoints were removed

Updates scrolling in MPQ to use the scroll-to mixin that's extracted from Tutor, and doesn't focus text boxes until scrolling is complete, and focuses the correct textbox.
