### PR TITLE
ArbitraryHtmlAndMath components decide when to wrap an iframe

### DIFF
--- a/src/helpers/html-videos.coffee
+++ b/src/helpers/html-videos.coffee
@@ -13,9 +13,12 @@ getRatioClass = (frame) ->
 isEmbedded = (frame) ->
   frame.parentNode?.classList.contains('embed-responsive')
 
+isInteractive = (frame) ->
+  frame.classList.contains('interactive')
+
 wrapFrames = (dom, shouldExcludeFrame) ->
   _.each(dom.getElementsByTagName('iframe'), (frame) ->
-    return null if isEmbedded(frame) or shouldExcludeFrame?(frame)
+    return null if isEmbedded(frame) or isInteractive(frame) or shouldExcludeFrame?(frame)
 
     wrapper = document.createElement("div")
     wrapper.className = "frame-wrapper embed-responsive #{getRatioClass(frame)}"


### PR DESCRIPTION
ArbitraryHtmlAndMath components can now self-determine whether an iframe should be wrapped or not based on whether it has the "interactive" class on it.  Note that if it is not an interactive iframe, the result of `shouldExcludeFrame` can still keep it from wrapping if it pleases.
