### PR TITLE
Fix MathML rendering

### DIFF
--- a/src/helpers/mathjax.coffee
+++ b/src/helpers/mathjax.coffee
@@ -10,7 +10,7 @@ COMBINED_MATH_SELECTOR = "#{MATH_DATA_SELECTOR}, #{MATH_ML_SELECTOR}"
 
 # Search document for math and [data-math] elements and then typeset them
 typesetDocument = ->
-  allNodes = []
+  latexNodes = []
 
   for node in document.querySelectorAll(MATH_DATA_SELECTOR)
     formula = node.getAttribute('data-math')
@@ -19,19 +19,21 @@ typesetDocument = ->
       node.textContent = "#{MATH_MARKER_BLOCK}#{formula}#{MATH_MARKER_BLOCK}"
     else
       node.textContent = "#{MATH_MARKER_INLINE}#{formula}#{MATH_MARKER_INLINE}"
-    allNodes.push(node)
+    latexNodes.push(node)
+
+  unless _.isEmpty(latexNodes)
+    window.MathJax.Hub.Typeset(latexNodes)
 
   mathMLNodes = _.toArray(document.querySelectorAll(MATH_ML_SELECTOR))
-  hasMathML = not _.isEmpty(mathMLNodes)
-  allNodes = allNodes.concat(mathMLNodes)
+  unless _.isEmpty(mathMLNodes)
+    # ugg - mathjax seems to need at least a bit of other content around the element to style
+    # If it just styles a parent element that has no other text then it doesn't know what size the text should be
+    parents = _.unique( _.map( mathMLNodes, (el) -> el.parentElement.parentElement ) )
+    window.MathJax.Hub.Typeset( parents )
 
-  # MathJax sometimes fails to set the height/width properly when processing individual mathml elements
-  # If we have any of those nodes then mark the entire document for processing
-  window.MathJax.Hub.Typeset( if hasMathML then document.body else allNodes )
   window.MathJax.Hub.Queue ->
-    # Queue a call to mark the found nodes as rendered so
-    # they can be ignored if typesetting is called repeatedly
-    for node in allNodes
+    # Queue a call to mark the found nodes as rendered so are ignored if typesetting is called repeatedly
+    for node in latexNodes.concat(mathMLNodes)
       node.classList.add(MATH_RENDERED_CLASS)
 
 # Install a debounce around typesetting function so that it will only run once

--- a/src/helpers/mathjax.coffee
+++ b/src/helpers/mathjax.coffee
@@ -37,7 +37,7 @@ typesetDocument = ->
       node.classList.add(MATH_RENDERED_CLASS)
 
 # Install a debounce around typesetting function so that it will only run once
-# every 10ms even if called multiple times in that period
+# every Xms even if called multiple times in that period
 typesetDocument = _.debounce( typesetDocument, 100)
 
 


### PR DESCRIPTION
If the mathml element's parent is shared with other mathml elements then it may be processed repeatedly, leading to the elements having zero height or width set on their inline styles.

This switches to simply processing the entire document when any `math` elments are found.

Fixes stuff like:
![screen shot 2016-07-06 at 12 21 40 pm](https://cloud.githubusercontent.com/assets/79566/16627746/4226ab1a-4374-11e6-8c37-6f3c5864c3fd.png)

After the fix it renders as:
![screen shot 2016-07-06 at 12 21 52 pm](https://cloud.githubusercontent.com/assets/79566/16627757/539a0d88-4374-11e6-8df4-ec18d0d57c12.png)
