### PR TITLE
Scroll to step using the step index, not MPQ index

### DIFF
--- a/src/components/exercise/index.cjsx
+++ b/src/components/exercise/index.cjsx
@@ -70,7 +70,7 @@ ExerciseMixin =
         includeGroup: false
         includeFooter: @shouldControl(part.id)
         keySet: keySet
-        stepPartIndex: index
+        stepPartIndex: part.stepIndex
         key: "exercise-part-#{index}"
 
       # stim and stem are the same for different steps currently.


### PR DESCRIPTION
Wasn't caught during testing because our test MPQ question was the first one, so the indexes matched up
