### PR TITLE
Typeset document when mathml is present

### DIFF
--- a/src/helpers/mathjax.coffee
+++ b/src/helpers/mathjax.coffee
@@ -26,10 +26,8 @@ typesetDocument = ->
 
   mathMLNodes = _.toArray(document.querySelectorAll(MATH_ML_SELECTOR))
   unless _.isEmpty(mathMLNodes)
-    # ugg - mathjax seems to need at least a bit of other content around the element to style
-    # If it just styles a parent element that has no other text then it doesn't know what size the text should be
-    parents = _.unique( _.map( mathMLNodes, (el) -> el.parentElement.parentElement ) )
-    window.MathJax.Hub.Typeset( parents )
+    # style the entire document because mathjax is unable to style individual math elements
+    window.MathJax.Hub.Typeset( window.document )
 
   window.MathJax.Hub.Queue ->
     # Queue a call to mark the found nodes as rendered so are ignored if typesetting is called repeatedly

--- a/src/helpers/mathjax.coffee
+++ b/src/helpers/mathjax.coffee
@@ -9,10 +9,9 @@ MATH_ML_SELECTOR   = "math:not(.#{MATH_RENDERED_CLASS})"
 COMBINED_MATH_SELECTOR = "#{MATH_DATA_SELECTOR}, #{MATH_ML_SELECTOR}"
 
 # Search document for math and [data-math] elements and then typeset them
-typesetDocument = ->
+typesetDocument = (windowImpl) ->
   latexNodes = []
-
-  for node in document.querySelectorAll(MATH_DATA_SELECTOR)
+  for node in windowImpl.document.querySelectorAll(MATH_DATA_SELECTOR)
     formula = node.getAttribute('data-math')
     # divs should be rendered as a block, others inline
     if node.tagName.toLowerCase() is 'div'
@@ -22,14 +21,14 @@ typesetDocument = ->
     latexNodes.push(node)
 
   unless _.isEmpty(latexNodes)
-    window.MathJax.Hub.Typeset(latexNodes)
+    windowImpl.MathJax.Hub.Typeset(latexNodes)
 
-  mathMLNodes = _.toArray(document.querySelectorAll(MATH_ML_SELECTOR))
+  mathMLNodes = _.toArray(windowImpl.document.querySelectorAll(MATH_ML_SELECTOR))
   unless _.isEmpty(mathMLNodes)
     # style the entire document because mathjax is unable to style individual math elements
-    window.MathJax.Hub.Typeset( window.document )
+    windowImpl.MathJax.Hub.Typeset( windowImpl.document )
 
-  window.MathJax.Hub.Queue ->
+  windowImpl.MathJax.Hub.Queue ->
     # Queue a call to mark the found nodes as rendered so are ignored if typesetting is called repeatedly
     for node in latexNodes.concat(mathMLNodes)
       node.classList.add(MATH_RENDERED_CLASS)
@@ -38,13 +37,12 @@ typesetDocument = ->
 # every Xms even if called multiple times in that period
 typesetDocument = _.debounce( typesetDocument, 100)
 
-
 # typesetMath is the main exported function.
 # It's called by components like HTML after they're rendered
-typesetMath = (root) ->
+typesetMath = (root, windowImpl = window) ->
   # schedule a Mathjax pass if there is at least one [data-math] or <math> element present
-  if window.MathJax?.Hub?.Queue? and root.querySelector(COMBINED_MATH_SELECTOR)
-    typesetDocument()
+  if windowImpl.MathJax?.Hub?.Queue? and root.querySelector(COMBINED_MATH_SELECTOR)
+    typesetDocument(windowImpl)
 
 
 # The following should be called once and configures MathJax.

--- a/test/helpers/fake-window.coffee
+++ b/test/helpers/fake-window.coffee
@@ -1,11 +1,19 @@
+_ = require 'underscore'
+
+EmptyFn = ->
+  return undefined
+
 class FakeWindow
-  clearInterval: sinon.spy()
-  setInterval: sinon.spy -> Math.random()
+  clearInterval: EmptyFn
+  setInterval: -> Math.random()
   localStorage:
-    getItem: sinon.stub().returns('[]')
-    setItem: sinon.stub()
+    getItem: -> []
+    setItem: EmptyFn
   document:
     hidden: false
 
+  constructor: ->
+    for method in _.functions(@)
+      sinon.spy(@, method)
 
 module.exports = FakeWindow

--- a/test/helpers/fake-window.coffee
+++ b/test/helpers/fake-window.coffee
@@ -6,14 +6,14 @@ EmptyFn = ->
 class FakeWindow
   clearInterval: EmptyFn
   setInterval: -> Math.random()
-  localStorage:
-    getItem: -> []
-    setItem: EmptyFn
   document:
     hidden: false
 
   constructor: ->
     for method in _.functions(@)
       sinon.spy(@, method)
+    @localStorage =
+      getItem: sinon.stub().returns('[]')
+      setItem: sinon.stub()
 
 module.exports = FakeWindow

--- a/test/helpers/mathjax.spec.coffee
+++ b/test/helpers/mathjax.spec.coffee
@@ -1,0 +1,41 @@
+{Testing, expect, sinon, _} = require './index'
+
+{typesetMath} = require 'helpers/mathjax'
+FakeWindow = require './fake-window'
+
+callTypeset = (dom, window) ->
+  new Promise( ( res, rej ) ->
+    typesetMath(dom, window)
+    _.delay ->
+      res(dom)
+    , 110
+  )
+
+
+describe 'Mathjax Helper', ->
+
+  beforeEach ->
+    @dom = document.createElement('div')
+    @window = new FakeWindow
+    @window.MathJax = { Hub: {Typeset: sinon.spy(), Queue: sinon.spy()} }
+    @window.document = @dom
+
+  it 'can typeset latex', ->
+    @dom.innerHTML = '<div data-math="\\pi">a pi symbol</div>'
+    callTypeset(@dom, @window).then =>
+      expect( @window.MathJax.Hub.Typeset ).to.have.been.calledWith([@dom.children[0]])
+      expect( @dom.textContent ).to.include('\\pi')
+
+
+  it 'typesets document with mathml is present', ->
+    @dom.innerHTML = '''
+      <math xmlns="http://www.w3.org/1998/Math/MathML"1
+            display="inline">2
+        <mrow>
+          <mi>PI</mi>
+        </mrow>
+      </math>
+    '''
+    callTypeset(@dom, @window).then =>
+      expect( @window.MathJax.Hub.Typeset ).to.have.been.calledWith(@window.document)
+      expect( @dom.textContent ).to.include('PI')


### PR DESCRIPTION
Fixes the same issue addressed by https://github.com/openstax/react-components/pull/93  In that PR we passed the grandparent of the math element to mathjax, which works on most math.  However college Physics section 2.5 has instances where it fails.  Rather than trying to special case it further, this simply typesets the entire document.

Turns stuff like:
![screen shot 2016-07-25 at 1 47 01 pm](https://cloud.githubusercontent.com/assets/79566/17113021/49cea832-526e-11e6-89ed-c077bff27874.png)

Into:
![screen shot 2016-07-25 at 1 48 40 pm](https://cloud.githubusercontent.com/assets/79566/17113065/84dc68c4-526e-11e6-9fae-475d52ffcd84.png)
